### PR TITLE
feat: standardize tool action descriptions for consistency

### DIFF
--- a/nodes/BrightData/MarketplaceDatasetDescription.ts
+++ b/nodes/BrightData/MarketplaceDatasetDescription.ts
@@ -16,7 +16,7 @@ export const marketplaceDatasetOperations: INodeProperties[] = [
 			{
 				name: "Deliver Snapshot",
 				value: 'deliverSnapshot',
-				action: 'Deliver the dataset snapshot',
+				action: 'Deliver a snapshot to specified storage',
 				routing: {
 					request: {
 						method: 'POST',
@@ -28,7 +28,7 @@ export const marketplaceDatasetOperations: INodeProperties[] = [
 			{
 				name: 'Filter Dataset',
 				value: 'filterDataset',
-				action: 'Create a dataset snapshot based on a provided filter',
+				action: 'Filter a dataset to create a snapshot',
 				routing: {
 					request: {
 						method: 'POST',
@@ -44,7 +44,7 @@ export const marketplaceDatasetOperations: INodeProperties[] = [
 			{
 				name: 'Get Dataset Metadata',
 				value: 'getDatasetMetadata',
-				action: 'Retrieve detailed metadata for a specific dataset',
+				action: 'Retrieve metadata for a specific dataset (by dataset ID)',
 				routing: {
 					request: {
 						method: 'GET',
@@ -55,7 +55,7 @@ export const marketplaceDatasetOperations: INodeProperties[] = [
 			{
 				name: 'Get Snapshot Content',
 				value: 'getSnapshotContent',
-				action: 'Get dataset snapshot content',
+				action: 'Retrieve data (by snapshot ID)',
 				routing: {
 					request: {
 						method: 'GET',
@@ -72,7 +72,7 @@ export const marketplaceDatasetOperations: INodeProperties[] = [
 			{
 				name: 'Get Snapshot Metadata',
 				value: 'getSnapshotMetadata',
-				action: 'Get dataset snapshot metadata',
+				action: 'Get metadata for a selected snapshot (by snapshot ID)',
 				routing: {
 					request: {
 						method: 'GET',
@@ -83,7 +83,7 @@ export const marketplaceDatasetOperations: INodeProperties[] = [
 			{
 				name: 'Get Snapshot Parts',
 				value: 'getSnapshotParts',
-				action: 'Get dataset snapshot delivery parts',
+				action: 'Split snapshot data to parts (by snapshot ID)',
 				routing: {
 					request: {
 						method: 'GET',
@@ -95,7 +95,7 @@ export const marketplaceDatasetOperations: INodeProperties[] = [
 			{
 				name: 'List Datasets',
 				value: 'listDatasets',
-				action: 'Retrieve a list of available datasets',
+				action: 'List available datasets',
 				routing: {
 					request: {
 						method: 'GET',
@@ -107,7 +107,7 @@ export const marketplaceDatasetOperations: INodeProperties[] = [
 			{
 				name: 'List Snapshots',
 				value: 'listSnapshots',
-				action: 'Get dataset snapshots',
+				action: 'List all your snapshot IDs',
 				routing: {
 					request: {
 						method: 'GET',

--- a/nodes/BrightData/WebScrapperDescription.ts
+++ b/nodes/BrightData/WebScrapperDescription.ts
@@ -16,7 +16,7 @@ export const webScrapperOperations: INodeProperties[] = [
 			{
 				name: "Deliver Snapshot",
 				value: 'deliverSnapshot',
-				action: 'Deliver the snapshot content to the specified storage',
+				action: 'Deliver a snapshot to specified storage',
 				routing: {
 					request: {
 						method: 'POST',
@@ -58,7 +58,7 @@ export const webScrapperOperations: INodeProperties[] = [
 			{
 				name: 'Monitor Progress Snapshot',
 				value: 'monitorProgressSnapshot',
-				action: 'Monitor the progress of a snapshot',
+				action: 'Check the status of a batch extraction',
 				routing: {
 					request: {
 						method: 'GET',
@@ -70,7 +70,7 @@ export const webScrapperOperations: INodeProperties[] = [
 			{
 				name: 'Scrape By URL',
 				value: 'scrapeByUrl',
-				action: 'Scrape data synchronously by URL',
+				action: 'Extract structured data from a single URL',
 				routing: {
 					request: {
 						method: 'POST',
@@ -87,7 +87,7 @@ export const webScrapperOperations: INodeProperties[] = [
 			{
 				name: 'Trigger Collection By URL',
 				value: 'triggerCollectionByUrl',
-				action: 'Trigger a collection and generate a snapshot by URL',
+				action: 'Initiate batch extraction from URL',
 				routing: {
 					request: {
 						method: 'POST',

--- a/nodes/BrightData/WebUnlockerDescription.ts
+++ b/nodes/BrightData/WebUnlockerDescription.ts
@@ -16,7 +16,7 @@ export const webUnlockerOperations: INodeProperties[] = [
 			{
 				name: 'Send a Request',
 				value: 'request',
-				action: 'Perform a request',
+				action: 'Access and extract data from a specific URL',
 				routing: {
 					request: {
 						method: 'POST',


### PR DESCRIPTION
Updates action descriptions across all Bright Data tools to follow consistent naming conventions:

**Changes:**
- **MarketplaceDataset**: Simplified and standardized 8 action descriptions
- **WebScrapper**: Updated 4 action descriptions for clarity  
- **WebUnlocker**: Refined 1 action description

**Key improvements:**
- More concise and user-friendly language
- Clear action-oriented descriptions
- Better alignment with actual functionality

**Examples:**
- "Retrieve detailed metadata for a specific dataset" → "Retrieve metadata for a specific dataset (by dataset ID)"
- "Scrape data synchronously by URL" → "Extract structured data from a single URL"
- "Perform a request" → "Access and extract data from a specific URL"

No functional changes - UI text updates only.

- [x] Tested that functionality remains the same